### PR TITLE
Refactor interests, Various fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "simple-import-sort"],
+  "plugins": ["react", "react-hooks", "@typescript-eslint", "simple-import-sort"],
   "rules": {
     "@typescript-eslint/consistent-type-imports": [
       "error",
@@ -83,6 +83,7 @@
         ]
       }
     ],
-    "comma-dangle": ["error", "never"]
+    "comma-dangle": ["error", "never"],
+    "react-hooks/exhaustive-deps": "error"
   }
 }

--- a/src/components/Common/LateralInfo.tsx
+++ b/src/components/Common/LateralInfo.tsx
@@ -15,7 +15,7 @@ const LateralLinks : FC = () => {
       <div className="w-px h-40 border border-gray-700" />
 
       <div
-        className="pointer py-4 text-gray-600 hover:text-bluegray-200 transition-all duration-700"
+        className="cursor-pointer py-4 text-gray-600 hover:text-bluegray-200 transition-all duration-700"
         onClick={() => window.scrollTo(0, 0)}
         title="Scroll to top"
       >

--- a/src/components/Interests/InterestProjectExample.tsx
+++ b/src/components/Interests/InterestProjectExample.tsx
@@ -23,7 +23,7 @@ const InterestProjectExample : FC<{ name : string }> = ({ name }) => {
     }
 
     fetch()
-  }, [])
+  }, [name])
 
   if (loading || !repo) {
     return (

--- a/src/components/Interests/InterestSection.tsx
+++ b/src/components/Interests/InterestSection.tsx
@@ -33,7 +33,8 @@ const InterestSection : FC<{interest : props}> = ({ interest }) => {
     <div
       ref={ref} key={interest.title}
       onClick={() => setOpen(!isOpen)}
-      className="relative flex flex-col w-full py-8 text-center overflow-hidden group transition-all duration-700">
+      className="cursor-pointer relative flex flex-col w-full py-8 text-center overflow-hidden group transition-all duration-700">
+
       <h2 className="text-2xl uppercase font-bold">
         <span className="bg-gradient-to-r from-gray-400 to-bluegray-600 bg-no-repeat bg-[size:80%_30%] bg-[position:50%_97%] group-hover:bg-[size:100%_30%] group-hover:bg-[position:0%_97%] transition-all duration-700">{interest.title}</span>
       </h2>

--- a/src/components/Interests/InterestSection.tsx
+++ b/src/components/Interests/InterestSection.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
 import React, { useEffect, useRef,useState } from "react"
+import { BsArrowsCollapse, BsArrowsExpand } from "react-icons/bs"
 import { Link } from "react-router-dom"
 
 import InterestProjectExample from "./InterestProjectExample"
@@ -13,53 +14,65 @@ interface props {
   projects : string[]
 }
 
-const InterestSection : FC<{interests : props[]}> = ({ interests }) => {
+const InterestSection : FC<{interest : props}> = ({ interest }) => {
+
+  const [isOpen, setOpen] = useState(false)
 
   const [height, setHeight] = useState<number | undefined>(0)
   const ref = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (ref) {
-      setHeight(ref.current?.clientHeight)
+      setTimeout(() => {
+        setHeight(ref.current?.clientHeight)
+      }, 700) // wait for transition (duration 700)
     }
-  }, [])
+  }, [isOpen])
 
   return (
-    <>
-      {interests.map(i =>
-        <div
-          ref={ref} key={i.title}
-          className="relative flex flex-col w-full py-10 text-center overflow-hidden group transition-all duration-700">
-          <h2 className="text-2xl uppercase font-bold">
-            <span className="bg-gradient-to-r from-gray-400 to-bluegray-600 bg-no-repeat bg-[size:80%_30%] bg-[position:50%_97%] group-hover:bg-[size:100%_30%] group-hover:bg-[position:0%_97%] transition-all duration-700">{i.title}</span>
-          </h2>
+    <div
+      ref={ref} key={interest.title}
+      onClick={() => setOpen(!isOpen)}
+      className="relative flex flex-col w-full py-8 text-center overflow-hidden group transition-all duration-700">
+      <h2 className="text-2xl uppercase font-bold">
+        <span className="bg-gradient-to-r from-gray-400 to-bluegray-600 bg-no-repeat bg-[size:80%_30%] bg-[position:50%_97%] group-hover:bg-[size:100%_30%] group-hover:bg-[position:0%_97%] transition-all duration-700">{interest.title}</span>
+      </h2>
 
-          <p className="text-xl w-7/12 m-auto my-6 text-gray-400 group-hover:text-gray-200 transition-all duration-700">{i.description}</p>
-          <p className="font-mono text-gray-500">{i.languages}</p>
+      <p className="text-xl w-7/12 m-auto my-6 text-gray-400 group-hover:text-gray-200 transition-all duration-700">{interest.description}</p>
+      <p className="font-mono text-gray-500">{interest.languages}</p>
 
-          <div className="opacity-0 h-0 group-hover:h-[22rem] group-hover:opacity-100 transition-all duration-700">
-            <div className="flex justify-center">
-              {i.projects.map(p => <InterestProjectExample key={p} name={p} />)}
-            </div>
-            <p className="italic text-gray-600">
-              And more... Visit
-              <Link to="/projects">
-                <span className="font-mono text-gray-400 tracking-tighter mx-2">/projects</span>
-              </Link>
-              page to view all projects.
-            </p>
-          </div>
-
-          <LateralIcons position="left-3" height={height ?? 0}>
-            {i.icons}
-          </LateralIcons>
-
-          <LateralIcons position="right-3" height={height ?? 0}>
-            {i.icons}
-          </LateralIcons>
+      <div className={`${isOpen ? "h-[22rem] opacity-100" : "h-0 opacity-0"} transition-all duration-700`}>
+        <div className="flex justify-center">
+          {interest.projects.map(p => <InterestProjectExample key={p} name={p} />)}
         </div>
-      )}
-    </>
+        <p className="italic text-gray-600">
+          And more... Visit
+          <Link to="/projects">
+            <span className="font-mono text-gray-400 tracking-tighter mx-2">/projects</span>
+          </Link>
+          page to view all projects.
+        </p>
+      </div>
+
+      {isOpen
+        ?
+        <h5 className="pointer mt-6 text-sm uppercase italic text-gray-500">
+            Hide related projects<BsArrowsCollapse className="inline ml-2" />
+        </h5>
+        :
+        <h5 className="pointer mt-6 text-sm uppercase italic text-gray-500">
+          Show related projects<BsArrowsExpand className="inline ml-2" />
+        </h5>
+      }
+
+      <LateralIcons position="left-3" height={height ?? 0}>
+        {interest.icons}
+      </LateralIcons>
+
+      <LateralIcons position="right-3" height={height ?? 0}>
+        {interest.icons}
+      </LateralIcons>
+    </div>
   )
 }
 

--- a/src/components/Interests/LateralIcons.tsx
+++ b/src/components/Interests/LateralIcons.tsx
@@ -19,8 +19,8 @@ const LateralIcons : FC<Props> = ({ children, position, height }) => {
   const repeat = ((height + CARD_HEIGHT) / CHILDREN_HEIGHT) + 1
 
   const render = []
-  for (let i = 0; i < repeat; i++) {
-    render.push(children)
+  for (let ri = 0; ri < repeat; ri++) {
+    render.push(children.map((icon, i) => <div className="my-1" key={`${ri}-${i}`}>{icon}</div>))
   }
 
   return (

--- a/src/components/Projects/FetchRepositoryDetails.tsx
+++ b/src/components/Projects/FetchRepositoryDetails.tsx
@@ -65,7 +65,7 @@ const FetchRepositoryDetails : FC<props> = ({ children, repository, reverse }) =
     fetchCollaborators()
     fetchLanguages()
 
-  }, [])
+  }, [repository.full_name])
 
   // calculate additional data (commits, last commit), triggered at collaborators load
   useEffect(() => {
@@ -79,7 +79,7 @@ const FetchRepositoryDetails : FC<props> = ({ children, repository, reverse }) =
     setAdditionalData({ totalCommits: commits, lastCommit })
 
     setLoading(false)
-  }, [collaborators])
+  }, [collaborators, repository.pushed_at])
 
   return (
     <>{children(loading, repository, reverse ?? undefined, collaborators, languages, additionalData)}</>

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -15,10 +15,12 @@ const Projects : FC = () => {
   const [normalRepos, setNormalRepos] = useState<Repository[]>()
   const [featuredRepos, setFeaturedRepos] = useState<Repository[]>()
 
-  const featRepos : string[] = ["favo02.dev", "workspaces-by-open-apps"]
-  const ignoredRepos : string[] = ["Favo02", "docker-compose", "preatoni-giardini", "FullStackOpen"]
-
   useEffect(() => {
+
+    const featRepos : string[] = ["favo02.dev", "workspaces-by-open-apps"]
+
+    const ignoredRepos : string[] = ["Favo02", "docker-compose", "preatoni-giardini", "FullStackOpen"]
+
     const fetch = async () => {
       setLoading(true)
       const allRepos = await repositoriesService.getAll()

--- a/src/components/Projects/ProjectsList.tsx
+++ b/src/components/Projects/ProjectsList.tsx
@@ -19,7 +19,7 @@ const Projects : FC = () => {
 
     const featRepos : string[] = ["favo02.dev", "workspaces-by-open-apps"]
 
-    const ignoredRepos : string[] = ["Favo02", "docker-compose", "preatoni-giardini", "FullStackOpen"]
+    const ignoredRepos : string[] = ["Favo02", "preatoni-giardini", "FullStackOpen"]
 
     const fetch = async () => {
       setLoading(true)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,6 +30,7 @@ const Home : FC = () => {
             <span className={`text-bluegray-100 italic ${underlineClass}`}>unimi</span>
           </Link>
         </h1>
+        <h3 className="italic text-xl text-gray-300 text-center mt-2 font-light">My full experience can be found in the <Link to="/about" className="font-normal underline decoration-dotted underline-offset-2">about</Link> page.</h3>
       </div>
 
       <div className="mt-20">

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -7,9 +7,17 @@ import InterestSection from "../components/Interests/InterestSection"
 
 import "../assets/styles/animations.css"
 
+interface Interest {
+  title : string,
+  description : string,
+  languages : string,
+  icons : React.ReactNode[],
+  projects : string[]
+}
+
 const Interests : FC = () => {
 
-  const interests = [
+  const interests : Interest[] = [
     {
       "title": "Competitive programming",
       "description": "I love solving complex problems as fast as possible: the only context where I tolerate messy code. But when time is over I refactor it.",
@@ -19,7 +27,6 @@ const Interests : FC = () => {
         <TbBrandGolang key="Go" />,
         <FaPython key="Python" />
       ],
-      "iconsRepeat": 4,
       "projects": ["advent-of-code", "cloudflight-coding-contest-2023"]
     },
     {
@@ -35,7 +42,6 @@ const Interests : FC = () => {
         <SiMongodb key="Mongo" />,
         <SiPostgresql key="Postgres" />
       ],
-      "iconsRepeat": 2,
       "projects": ["favo02.dev"]
     },
     {
@@ -46,7 +52,6 @@ const Interests : FC = () => {
         <FaJava key="Java" />,
         <TbBrandJavascript key="Javascript" />
       ],
-      "iconsRepeat": 6,
       "projects": ["workspaces-by-open-apps", "java-algorithms-and-structures"]
     }
   ]

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -57,11 +57,14 @@ const Interests : FC = () => {
   ]
 
   return (
-    <div className="w-10/12 max-w-6xl m-auto mt-12 mb-20 text-gray-200 divide-y-2 divide-bluegray-600/50 divide-dashed  bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
+    <>
+      <h4 className="mt-4 text-2xl text-gray-200 text-center">My tech <span className="font-bold bg-gradient-to-r from-gray-400 via-bluegray-600 to-transparent bg-no-repeat bg-[size:100%_15%] bg-[position:0_98%]">interests</span>.</h4>
 
-      <InterestSection interests={interests} />
 
-    </div>
+      <div className="w-10/12 max-w-6xl m-auto mt-12 mb-20 text-gray-200 divide-y-2 divide-bluegray-600/50 divide-dashed  bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
+        {interests.map(i => <InterestSection interest={i} key={i.title} />)}
+      </div>
+    </>
   )
 }
 

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react"
-import { FaJava, FaPython } from "react-icons/fa"
-import { SiExpress, SiMongodb, SiPostgresql,SiReact, SiTailwindcss } from "react-icons/si"
+import { FaDocker, FaJava, FaPython } from "react-icons/fa"
+import { IoMdFlag } from "react-icons/io"
+import { SiC, SiExpress, SiGnubash, SiMongodb, SiPostgresql,SiReact, SiTailwindcss } from "react-icons/si"
 import { TbBrandGolang, TbBrandJavascript,TbBrandTypescript } from "react-icons/tb"
 
 import InterestSection from "../components/Interests/InterestSection"
@@ -53,6 +54,18 @@ const Interests : FC = () => {
         <TbBrandJavascript key="Javascript" />
       ],
       "projects": ["workspaces-by-open-apps", "java-algorithms-and-structures"]
+    },
+    {
+      "title": "Learning...",
+      "description": "I'm always looking forward to learning and practicing new things: currently experimenting with an old PC turned into an Home Server (hosting this!) and Docker. From time to time I love to catch some flags in Security CTFs (process interaction with C and shell injection in x86-64 assembly are my favourites).",
+      "languages": "Docker, Bash, C, x86-64",
+      "icons": [
+        <FaDocker key="docker" />,
+        <SiGnubash key="bash" />,
+        <IoMdFlag key="ctf" />,
+        <SiC key="c" />
+      ],
+      "projects": ["docker-compose"]
     }
   ]
 


### PR DESCRIPTION
Refactor interests:

- add `Interest` interface in `Interests`
- map `Interests` in `Interest` page instead of inside `InterestSection` component
- add `isOpen` to `InterestSection`
- add `margin-y` to `LateralIcons`
- add `Learning...` content to `Interests` page


Various fixes:

- add link to full education in `home`
- add and fix `exhaustive-deps` eslint rule
- remove `docker-compose` from ignored repos