### PR TITLE
Add responsive support (#54)

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -8,3 +8,4 @@
 - https://stackoverflow.com/a/70024111/14853184
 - https://stackoverflow.com/a/73902563/14853184
 - https://arslan-53763.medium.com/how-to-create-a-scroll-indicator-progress-bar-in-react-hooks-c38fff447329
+- https://stackoverflow.com/a/70247355/14853184

--- a/src/components/About/BioPicture.tsx
+++ b/src/components/About/BioPicture.tsx
@@ -6,7 +6,7 @@ import roundtext from "../../assets/images/about/RoundText.webp"
 
 const BioPicture : FC = () => (
   <div
-    className="float-right w-80 h-80 relative group rounded-full m-4"
+    className="float-right w-52 h-52 md:w-80 md:h-80 relative group rounded-full m-4"
     style={{ shapeOutside: "circle()" }}
   >
     <img className="absolute rounded-full" src={propic1} />

--- a/src/components/About/Biography.tsx
+++ b/src/components/About/Biography.tsx
@@ -32,7 +32,7 @@ const Biography : FC = () => {
   }
 
   return (
-    <div className="text-lg text-gray-300/90">
+    <div className="text-lg text-gray-300/90 text-justify md:text-left">
       <span className="my-3 block">
         Hello, I am <H>Luca Favini</H>, but my friends call me <H>Favo</H>. I am a {calculateAge(new Date("August 25, 2002"))}-year-old guy living <i>(near)</i> <H>Milan, Italy</H>.
       </span>

--- a/src/components/About/Education.tsx
+++ b/src/components/About/Education.tsx
@@ -62,17 +62,17 @@ const Education : FC = () => {
   return (
     <>
       {education.map(e =>
-        <div key={e.name} className="flex w-full mt-6 group">
-          <div className="w-1/3 text-right pr-6 text-bluegray-600 group-hover:text-bluegray-500 opacity-80 italic transition-all duration-700">{e.start}{e.end ? ` - ${e.end}` : ""}</div>
+        <div key={e.name} className="flex flex-col md:flex-row w-5/6 mx-auto md:w-full mt-6 group text-center">
+          <div className="w-full md:w-1/3 md:text-right pr-6 text-bluegray-600 group-hover:text-bluegray-500 opacity-80 italic transition-all duration-700">{e.start}{e.end ? ` - ${e.end}` : ""}</div>
           <Link to={e.link} target="_blank">
-            <h1 className="text-xl font-bold text-gray-300 group-hover:text-gray-200 transition-all duration-700">
+            <h1 className="text-xl md:text-left font-bold text-gray-300 group-hover:text-gray-200 transition-all duration-700">
               {e.name}, {e.location}
               <BiLink className="inline -mt-1 ml-1" />
               {e.isCertificate &&
                 <span className="text-xs border font-black text-green-600/30 border-green-800/30 rounded-md ml-1 py-0.5 px-2">CERTIFICATE</span>
               }
             </h1>
-            <h2 className="text-gray-500 group-hover:text-gray-400 transition-all duration-700">{e.description}</h2>
+            <h2 className="text-gray-500 md:text-left group-hover:text-gray-400 transition-all duration-700">{e.description}</h2>
           </Link>
         </div>
       )}

--- a/src/components/Common/ContentWrapper.tsx
+++ b/src/components/Common/ContentWrapper.tsx
@@ -3,6 +3,8 @@ import { useEffect,useState } from "react"
 import AnimatedCursor from "react-animated-cursor"
 import { Outlet } from "react-router-dom"
 
+import useIsSmallDevice from "../../hooks/useIsSmallDevice"
+
 import Footer from "./Footer"
 import Header from "./Header"
 import LateralInfo from "./LateralInfo"
@@ -13,6 +15,8 @@ import ResetScroll from "./ResetScroll"
 import Scrollbar from "./Scrollbar"
 
 const ContentWrapper : FC = () => {
+
+  const [isSmallDevice] = useIsSmallDevice()
 
   const [loading, setLoading] = useState<boolean>(true)
 
@@ -34,29 +38,30 @@ const ContentWrapper : FC = () => {
       <Header />
       <PagePath />
       <Outlet />
-      <LateralInfo />
-      <LateralLinks />
+      {!isSmallDevice && <LateralInfo />}
+      {!isSmallDevice && <LateralLinks />}
       <Footer />
 
       <Scrollbar customClasses="left-0" />
       <Scrollbar customClasses="right-0" />
-
-      <AnimatedCursor
-        color="159, 179, 200"
-        innerSize={8}
-        innerScale={0.5}
-        outerSize={20}
-        outerScale={3}
-        outerAlpha={0.3}
-        outerStyle={{
-          background: "rgb(34, 45, 61, 0.5)"
-        }}
-        clickables={[
-          "a",
-          ".cursor-pointer"
-        ]}
-        showSystemCursor={true}
-      />
+      {!isSmallDevice &&
+        <AnimatedCursor
+          color="159, 179, 200"
+          innerSize={8}
+          innerScale={0.5}
+          outerSize={20}
+          outerScale={3}
+          outerAlpha={0.3}
+          outerStyle={{
+            background: "rgb(34, 45, 61, 0.5)"
+          }}
+          clickables={[
+            "a",
+            ".cursor-pointer"
+          ]}
+          showSystemCursor={true}
+        />
+      }
 
     </ResetScroll>
   )

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -33,14 +33,10 @@ const Header : FC = () => {
 
   const navLinks = [ "home", "projects", "interests", "about" ]
 
-  const navLinkActiveClasses = "font-mono pl-1 text-gray-100 bg-gradient-to-r from-gray-400 to-transparent bg-no-repeat bg-[size:100%_20%] bg-[position:0_88%] transition-all duration-700"
-
-  const navLinkInactiveClasses = "font-mono pl-1 text-gray-300 hover:text-gray-100 hover:tracking-widest hover:bg-gradient-to-r hover:from-gray-600 hover:to-transparent bg-no-repeat bg-[size:100%_0.3em] bg-[position:0_88%] transition-all duration-700"
-
   return (
     <div className="w-full flex justify-center items-center fixed z-10" ref={headerRef}>
 
-      <div className={`w-10/12 max-w-5xl ${isOpen ? "h-28" : "h-14"} mt-8 bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black/30 transition-all duration-700 overflow-hidden`}>
+      <div className={`w-10/12 max-w-5xl ${isOpen ? "h-60 md:h-28" : "h-14"} mt-8 bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black/30 transition-all duration-700 overflow-hidden`}>
 
         {/* Logo + Menu toggle */}
         <div className="flex justify-between items-center h-14">
@@ -61,15 +57,15 @@ const Header : FC = () => {
         </div>
 
         {/* Menu */}
-        <div className="flex justify-evenly items-center h-14 text-gray-300">
+        <div className="flex flex-col md:flex-row justify-start md:justify-evenly items-center h-full md:h-14 text-gray-300">
           {navLinks.map(n =>
             <NavLink
               key={n}
               to={`/${n}`}
               text={n}
               setOpen={setOpen}
-              activeClass={navLinkActiveClasses}
-              inactiveClass={navLinkInactiveClasses}
+              activeClass="text-xl md:text-base mt-3 md:mt-0 font-mono pl-1 text-gray-100 bg-gradient-to-r from-gray-400 to-transparent bg-no-repeat bg-[size:100%_20%] bg-[position:0_88%] transition-all duration-700"
+              inactiveClass="text-xl md:text-base mt-3 md:mt-0 font-mono pl-1 text-gray-300 hover:text-gray-100 hover:tracking-widest hover:bg-gradient-to-r hover:from-gray-600 hover:to-transparent bg-no-repeat bg-[size:100%_0.3em] bg-[position:0_88%] transition-all duration-700"
               addSlash={true}
             />)
           }

--- a/src/components/Common/Scrollbar.tsx
+++ b/src/components/Common/Scrollbar.tsx
@@ -21,12 +21,9 @@ const Scrollbar : FC<{customClasses ?: string}> = ({ customClasses }) => {
   }
 
   return (
-    <div className={`fixed top-0 right-0 w-1.5 h-screen z-10 bg-bluegithub-dark ${customClasses}`}>
-      <div
-        className="w-1.5 bg-gradient-to-b from-bluegray-800 to-bluegray-400 z-20"
-        style={{ height: `${scrollTop}%` }}
-      />
-    </div>
+    <div className={`fixed top-0 w-0.5 md:w-1.5 bg-gradient-to-b from-bluegray-800 to-bluegray-400 z-20 ${customClasses}`}
+      style={{ height: `${scrollTop}%` }}
+    />
   )
 }
 

--- a/src/components/Home/OverlappingCards.tsx
+++ b/src/components/Home/OverlappingCards.tsx
@@ -9,13 +9,13 @@ interface content {
 }
 
 const OverlappingCards : FC<{content : content[]}> = ({ content }) => (
-  <div className="flex justify-center max-w-6xl m-auto">
+  <div className="flex flex-col md:flex-row justify-center max-w-6xl m-auto">
     {content.map(c => <Card key={c.title} c={c} />)}
   </div>
 )
 
 const Card : FC<{ c : content }> = ({ c }) => (
-  <div className="flex flex-col relative h-72 w-full bg-gray-400 bg-opacity-20 backdrop-blur-lg rounded-xl -ml-12 first:ml-0 shadow-xl shadow-black hover:-translate-y-5 group/card left-0 peer peer-hover:left-10 transition-all duration-700">
+  <div className="flex flex-col relative h-80 md:h-72 w-full mb-6 md:mb-0 bg-gray-400 bg-opacity-20 backdrop-blur-lg rounded-xl md:-ml-12 md:first:ml-0 shadow-xl shadow-black md:hover:-translate-y-5 group/card left-0 peer md:peer-hover:left-10 transition-all duration-700">
     <h3 className="basis-1/6 text-2xl font-bold text-gray-100 ml-5 mt-5">{c.title}</h3>
 
     <div className="basis-1/6 relative mx-auto max-h-1 w-5/6">

--- a/src/components/Interests/InterestProjectExample.tsx
+++ b/src/components/Interests/InterestProjectExample.tsx
@@ -27,7 +27,7 @@ const InterestProjectExample : FC<{ name : string, user : string }> = ({ name, u
 
   if (loading || !repo) {
     return (
-      <div className="flex items-center justify-center w-80 h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
+      <div className="flex items-center justify-center w-72 md:w-80 h-80 md:h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
         <Loading />
       </div>
     )

--- a/src/components/Interests/InterestSection.tsx
+++ b/src/components/Interests/InterestSection.tsx
@@ -3,12 +3,15 @@ import React, { useEffect, useRef,useState } from "react"
 import { BsArrowsCollapse, BsArrowsExpand } from "react-icons/bs"
 import { Link } from "react-router-dom"
 
+import useIsSmallDevice from "../../hooks/useIsSmallDevice"
 import type Interest from "../../interfaces/Interest"
 
 import InterestProjectExample from "./InterestProjectExample"
 import LateralIcons from "./LateralIcons"
 
 const InterestSection : FC<{interest : Interest}> = ({ interest }) => {
+
+  const [isSmallDevice] = useIsSmallDevice()
 
   const [isOpen, setOpen] = useState(false)
 
@@ -29,15 +32,15 @@ const InterestSection : FC<{interest : Interest}> = ({ interest }) => {
       onClick={() => setOpen(!isOpen)}
       className="cursor-pointer relative flex flex-col w-full py-8 text-center overflow-hidden group transition-all duration-700">
 
-      <h2 className="text-2xl uppercase font-bold">
+      <h2 className="text-xl md:text-2xl uppercase font-bold">
         <span className="bg-gradient-to-r from-gray-400 to-bluegray-600 bg-no-repeat bg-[size:80%_30%] bg-[position:50%_97%] group-hover:bg-[size:100%_30%] group-hover:bg-[position:0%_97%] transition-all duration-700">{interest.title}</span>
       </h2>
 
-      <p className="text-xl w-7/12 m-auto my-6 text-gray-400 group-hover:text-gray-200 transition-all duration-700">{interest.description}</p>
-      <p className="font-mono text-gray-500">{interest.languages}</p>
+      <p className="text-lg md:text-xl w-7/12 m-auto my-6 text-gray-400 group-hover:text-gray-200 transition-all duration-700">{interest.description}</p>
+      <p className="text-sm max-w-[70%] mx-auto md:text-base font-mono text-gray-500">{interest.languages}</p>
 
-      <div className={`${isOpen ? "h-[22rem] opacity-100" : "h-0 opacity-0"} transition-all duration-700`}>
-        <div className="flex justify-center">
+      <div className={`${isOpen ? "h-[48rem] md:h-[22rem] opacity-100" : "h-0 opacity-0"} transition-all duration-700`}>
+        <div className="flex flex-row flex-wrap items-center justify-center">
           {interest.projects.map(p => <InterestProjectExample key={p.name} name={p.name} user={p.owner} />)}
         </div>
         <p className="italic text-gray-600">
@@ -60,13 +63,17 @@ const InterestSection : FC<{interest : Interest}> = ({ interest }) => {
         </h5>
       }
 
-      <LateralIcons position="left-3" height={height ?? 0}>
-        {interest.icons}
-      </LateralIcons>
+      {!isSmallDevice &&
+      <>
+        <LateralIcons position="left-3" height={height ?? 0}>
+          {interest.icons}
+        </LateralIcons>
 
-      <LateralIcons position="right-3" height={height ?? 0}>
-        {interest.icons}
-      </LateralIcons>
+        <LateralIcons position="right-3" height={height ?? 0}>
+          {interest.icons}
+        </LateralIcons>
+      </>
+      }
     </div>
   )
 }

--- a/src/components/Projects/FeaturedProjectCard.tsx
+++ b/src/components/Projects/FeaturedProjectCard.tsx
@@ -22,19 +22,19 @@ const FeaturedProjectCard : FC<props> = ({ loading, repository, reverse, collabo
 
   if (loading) {
     return (
-      <div className="w-11/12 flex items-center justify-center relative h-72 mt-10 m-auto p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
+      <div className="w-11/12 flex items-center justify-center relative h-[30rem] md:h-72 mt-10 m-auto p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
         <Loading />
       </div>
     )
   }
 
   return (
-    <div className={"w-11/12 flex items-center justify-center relative h-72 mt-10 m-auto p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black overflow-hidden group" + (reverse ? " flex-row-reverse" : " flex-row")}>
+    <div className={"w-11/12 flex flex-col md:flex-row items-center justify-center relative h-[30rem] md:h-72 mt-10 m-auto pt-3 pb-6 md:p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black overflow-hidden group" + (reverse ? " flex-row-reverse" : " flex-row")}>
       <div className="absolute top-6 -left-11 bg-gradient-to-r from-bluegray-700 to-gray-500 opacity-100 w-40 -rotate-45 z-10 uppercase text-gray-100 font-bold text-sm">
         <h1>Featured</h1>
       </div>
 
-      <div className="w-1/2 h-full">
+      <div className="w-full md:w-1/2 h-3/5 md:h-full">
         <RepositoryContent
           repository={repository}
           languages={languages}
@@ -44,8 +44,8 @@ const FeaturedProjectCard : FC<props> = ({ loading, repository, reverse, collabo
         />
       </div>
 
-      <Link to={repository.homepage} target="_blank" className="w-1/2 h-full flex justify-center items-center">
-        <div className="relative w-11/12 h-[260px] rounded-xl overflow-hidden shadow-md shadow-black/50">
+      <Link to={repository.homepage} target="_blank" className="w-full md:w-1/2 h-2/5 md:h-full flex justify-center items-center">
+        <div className="relative w-11/12 h-full md:h-[260px] rounded-xl overflow-hidden shadow-md shadow-black/50">
           <DynamicImage fileName={`featured/${repository.name}.webp`} alt="Preview" className="group-hover:translate-y-[calc(-100%+260px)] translate-y-0 transition-transform duration-[3s] opacity-70" />
         </div>
         <div className="absolute flex justify-center items-center w-24 h-24 bg-black/80 rounded-full group-hover:opacity-100 opacity-0 transition-all duration-700">

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -20,14 +20,14 @@ const ProjectCard : FC<props> = ({ loading, repository, collaborators, languages
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center w-80 h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
+      <div className="flex items-center justify-center w-72 md:w-80 h-80 md:h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black">
         <Loading />
       </div>
     )
   }
 
   return (
-    <div className={`flex items-center justify-center relative w-80 h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black ${customClasses}`}>
+    <div className={`flex items-center justify-center relative w-72 md:w-80 h-80 md:h-72 m-6 p-0.5 text-center bg-gray-400 bg-opacity-20 rounded-xl backdrop-blur-lg shadow-xl shadow-black ${customClasses}`}>
       <RepositoryContent
         repository={repository}
         languages={languages}

--- a/src/components/Projects/RepositoryContent.tsx
+++ b/src/components/Projects/RepositoryContent.tsx
@@ -24,14 +24,14 @@ const RepositoryContent : FC<props> = ({ repository, languages, collaborators, a
     <div className={`m-auto w-full h-full py-4 px-2 flex items-center justify-center flex-col ${customClasses}`}>
 
       <div className="basis-3/12 mb-4">
-        <h1 className="text-2xl font-black text-gray-100 capitalize">{repository.name.replaceAll("-", " ")}</h1>
-        <div className="text-sm font-bold text-gray-600 italic">
+        <h1 className="text-xl md:text-2xl font-black text-gray-100 capitalize">{repository.name.replaceAll("-", " ")}</h1>
+        <div className="text-xs md:text-sm font-bold text-gray-600 italic">
           <Link to={repository.svn_url} target="_blank">{repository.full_name}</Link>
         </div>
       </div>
 
       <div className="basis-5/12">
-        <h4 className="text-bluegray-200">{repository.description}</h4>
+        <h4 className="text-sm md:text-base text-bluegray-200">{repository.description}</h4>
       </div>
 
       <div className="flex justify-center align-middle flex-col w-full basis-2/12">
@@ -39,8 +39,8 @@ const RepositoryContent : FC<props> = ({ repository, languages, collaborators, a
         <div className="opacity-60">
           <div>
             {languages &&
-              languages.map((l : Language) => (
-                <div key={l.language} className="text-bluegray-500 italic inline-block overflow-hidden mx-2">{l.percentage}% {l.language}</div>
+              languages.slice(0,3).map((l : Language) => (
+                <div key={l.language} className="text-sm md:text-base text-bluegray-500 italic inline-block overflow-hidden mx-2">{l.percentage}% {l.language}</div>
               ))
             }
           </div>
@@ -64,7 +64,7 @@ const RepositoryContent : FC<props> = ({ repository, languages, collaborators, a
 
       </div>
 
-      <div className="flex justify-evenly w-full basis-1/12 italic opacity-60 -mt-1 mb-1">
+      <div className="text-sm md:text-base flex justify-evenly w-full basis-1/12 italic opacity-60 -mt-1 mb-1">
         {repository.stargazers_count > 0 &&
           <h4 className="text-bluegray-500" title="Stars">
             {repository.stargazers_count} <FaRegStar className="inline -mt-1" />
@@ -98,11 +98,11 @@ const RepositoryContent : FC<props> = ({ repository, languages, collaborators, a
 
           <div className="flex justify-center align-middle flex-row ml-4">
             <Link to={repository.svn_url} target="_blank">
-              <FaGithub className="text-xl text-gray-100" />
+              <FaGithub className="text-lg md:text-xl text-gray-100" />
             </Link>
             {repository.homepage &&
               <Link to={repository.homepage} target="_blank" className="mx-0.5">
-                <FaGlobe className="text-xl text-gray-100" />
+                <FaGlobe className="text-lg md:text-xl text-gray-100" />
               </Link>
             }
           </div>

--- a/src/hooks/useIsSmallDevice.ts
+++ b/src/hooks/useIsSmallDevice.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+
+const useIsSmallDevice = (breakpoint = 768) => {
+
+  const [isSmallDevice, SetIsSmallDevice] = useState(window.innerWidth < breakpoint)
+
+  useEffect(() => {
+    const handlePageResized = () => {
+      SetIsSmallDevice(window.innerWidth < breakpoint)
+    }
+
+    if (window) {
+      window.addEventListener("resize", handlePageResized)
+      window.addEventListener("orientationchange", handlePageResized)
+      window.addEventListener("load", handlePageResized)
+      window.addEventListener("reload", handlePageResized)
+    }
+
+    return () => {
+      if (window) {
+        window.removeEventListener("resize", handlePageResized)
+        window.removeEventListener("orientationchange", handlePageResized)
+        window.removeEventListener("load", handlePageResized)
+        window.removeEventListener("reload", handlePageResized)
+      }
+    }
+
+  }, [breakpoint])
+
+  return [isSmallDevice]
+}
+
+export default useIsSmallDevice

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,26 +11,26 @@ const Home : FC = () => {
     <div className="w-10/12 max-w-6xl m-auto text-center">
       <div className="mt-14 text-center text-gray-100">
 
-        <h4 className="text-3xl uppercase font-light">Hello, I&apos;m</h4>
+        <h4 className="text-2xl md:text-3xl uppercase font-light">Hello, I&apos;m</h4>
 
-        <h4 className="text-5xl mt-6 font-light">
-          <Link to="/about"><span className={`text-6xl font-bold ${underlineClass}`}>Luca</span></Link>
+        <h4 className="text-4xl md:text-5xl mt-6 font-light">
+          <Link to="/about"><span className={`text-5xl md:text-6xl font-bold ${underlineClass}`}>Luca</span></Link>
           <span className="mx-2"> aka </span>
-          <Link to="/interests"><span className={`text-6xl font-mono font-bold ${underlineClass}`}>favo02</span></Link>
+          <Link to="/interests"><span className={`text-5xl md:text-6xl font-mono font-bold ${underlineClass}`}>favo02</span></Link>
         </h4>
 
-        <h4 className="text-2xl mt-6 italic font-light">or should I say <Link to="/about"><span className={`pr-0.5 font-normal ${underlineClass}`}>imprudenza</span></Link>?</h4>
+        <h4 className="text-xl md:text-2xl mt-6 italic font-light">or should I say <Link to="/about"><span className={`pr-0.5 font-normal ${underlineClass}`}>imprudenza</span></Link>?</h4>
 
       </div>
 
-      <div className="text-3xl mt-20">
+      <div className="text-2xl md:text-3xl mt-20">
         <h1 className="text-gray-200">
           <span>Currently studying computer science at </span>
           <Link to="https://en.wikipedia.org/wiki/University_of_Milan" target="_blank">
             <span className={`text-bluegray-100 italic ${underlineClass}`}>unimi</span>
           </Link>
         </h1>
-        <h3 className="italic text-xl text-gray-300 text-center mt-2 font-light">My full experience can be found in the <Link to="/about" className="font-normal underline decoration-dotted underline-offset-2">about</Link> page.</h3>
+        <h3 className="italic text-lg md:text-xl text-gray-300 text-center mt-2 font-light">My full experience can be found in the <Link to="/about" className="font-normal underline decoration-dotted underline-offset-2">about</Link> page.</h3>
       </div>
 
       <div className="mt-20">

--- a/src/pages/Interests.tsx
+++ b/src/pages/Interests.tsx
@@ -58,7 +58,7 @@ const Interests : FC = () => {
         <IoMdFlag key="ctf" />,
         <SiC key="c" />
       ],
-      "projects": [{ name: "docker-compose", owner: "Favo02" }]
+      "projects": [{ name: "docker-compose", owner: "Favo02" }, { name: "sicurezza-e-privatezza", owner: "Favo02-unimi" }]
     }
   ]
 


### PR DESCRIPTION
- add `useIsSmallDevice` hook
- hide elements on mobile in `ContentWrapper`
- add mobile support for common components (`header`, `footer`, ...)
- add mobile support for all pages:
  - `/home`
  - `/interests`
  - `/projects`
  - `/about`